### PR TITLE
docs: dahili depolama kurulum seçeneğini netleştir

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -49,9 +49,12 @@ This script has been tested on the following Keenetic OS versions:
 > On older versions, OPKG/Entware packages, iptables/ipset behaviour or binary compatibility may differ.
 
 ## ✅ Recommended Setup:
-- USB storage attached to the Keenetic device
-- Entware installed on USB
-- Script and Zapret running under `/opt/lib/opkg`
+KZM needs a working Entware/OPKG environment mounted under `/opt`. This `/opt`
+mount can be backed by internal storage or by a USB drive.
+
+- On newer Keenetic models with around 100 MB of internal storage, internal storage is usually enough for KZM/Zapret only.
+- On older low-storage models, or when using extra Entware packages, heavy logs, Web Panel/monitoring, USB/external storage is recommended.
+- The KZM script runs from `/opt/lib/opkg`, while Zapret files are managed under `/opt/zapret`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,12 @@ Bu betik aşağıdaki Keenetic OS sürümlerinde test edilmiştir:
 > Eski sürümlerde OPKG/Entware paketleri, iptables/ipset davranışı veya binary uyumluluğu farklı olabilir.
 
 ## ✅ Önerilen Kurulum:
-- Keenetic'e USB bellek takılı
-- Entware USB'ye kurulu
-- Betik ve Zapret `/opt/lib/opkg` altında çalışıyor olmalı
+KZM için Entware/OPKG ortamının `/opt` altında hazır olması gerekir. Bu `/opt`
+bağlantısı dahili depolama veya USB sürücü üzerinde olabilir.
+
+- Dahili depolaması yaklaşık 100 MB olan güncel Keenetic modellerinde sadece KZM/Zapret için dahili depolama genellikle yeterlidir.
+- Dahili depolaması düşük olan eski modellerde veya ek Entware paketleri, yoğun log, Web Panel/izleme gibi kullanım senaryolarında USB/harici depolama tavsiye edilir.
+- KZM betiği `/opt/lib/opkg`, Zapret dosyaları ise `/opt/zapret` altında çalışır.
 
 ---
 


### PR DESCRIPTION
## Özet
- README’deki önerilen kurulum bölümünde USB zorunlu gibi okunabilen ifadeleri netleştirdim.
- Entware/OPKG için gerekli olan şeyin `/opt` altında çalışan bir ortam olduğunu, bunun dahili depolama veya USB üzerinden gelebileceğini belirttim.
- README.en.md dosyasını da aynı anlamla güncelledim.

## Neden
Sıfırdan kurulum dokümanı dahili bellek ve USB seçeneklerini ayrı ayrı anlatıyor. README kısa hali ise USB şartmış gibi okunabiliyordu. KN-1812 gibi yaklaşık 100 MB dahili depolaması olan güncel modellerde sadece KZM/Zapret için dahili depolama yeterli olabiliyor.

## Test
- Doküman değişikliği olduğu için runtime testi yok.
- README.md ve README.en.md yan yana kontrol edildi.
- Eski USB-zorunlu ifadeler için repo içinde grep yapıldı.

## Gerçek cihaz doğrulaması
- Keenetic Titan KN-1812 / KeeneticOS 5.0.10 üzerinde KZM/Zapret iç depolamada çalışırken doğrulandı.