### PR TITLE
docs: Web Panel güven sınırını netleştir

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -37,6 +37,23 @@
 
 <img src="docs/images/KZM_Main5.png" width="800">
 
+> [!WARNING]
+> ## 🔒 Web Panel Security Note
+>
+> KZM Web Panel is intended to be used only from a **trusted private LAN**.
+>
+> **Not recommended:**
+> - exposing it to WAN / the Internet
+> - using port forwarding for Web Panel access
+> - allowing access from Guest networks
+> - allowing access from IoT/VLAN or other untrusted segments
+>
+> Web Panel can run **administrator-level actions** such as restarting Zapret, changing DPI profiles, managing hostlists/IPSET and running system operations.
+>
+> Changing the port number is not access control by itself. If you do not use the panel, keeping it disabled is recommended.
+>
+> For this reason, use it only from your trusted home/office management network.
+
 
 ## ✅ Tested Keenetic OS Versions
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@
 >
 > Web Panel; Zapret yeniden başlatma, DPI profili değiştirme, hostlist/IPSET yönetimi ve sistem işlemleri gibi **yönetici seviyesinde işlemler** yapabilir.
 >
+> Port numarasını değiştirmek tek başına erişim kontrolü değildir. Panel kullanılmıyorsa kapalı bırakılması önerilir.
+>
 > Bu nedenle yalnızca **ev/ofis içindeki güvenilir yönetim ağı** üzerinden kullanılması önerilir.
 
 

--- a/docs/kullanim_klavuzu.md
+++ b/docs/kullanim_klavuzu.md
@@ -663,6 +663,11 @@ Tarayıcı üzerinden erişilebilen görsel yönetim paneli.
 
 Varsayılan port: **8088** → `http://<router-ip>:8088`
 
+> [!WARNING]
+> Web Panel yalnızca **güvenilir yerel ağ** üzerinden kullanılmalıdır. WAN'a, port forward ile internete, misafir ağına veya IoT/VLAN gibi güvenilmeyen segmentlere açılması önerilmez.
+>
+> Panel; Zapret başlatma/durdurma, DPI profili değiştirme, hostlist/IPSET düzenleme ve OPKG işlemleri gibi yönetici seviyesinde komutlar çalıştırabilir. Port numarasını değiştirmek tek başına erişim kontrolü değildir; kullanılmıyorsa paneli kapalı bırakın.
+
 ### Alt Menü:
 
 ✔ **Web Panel Kur** — lighttpd + CGI kurulur, cron ile durum yenileme aktif edilir, iptables kuralı açılır  


### PR DESCRIPTION
## Summary / What changed

- README.md içindeki Web Panel güvenlik notuna port değiştirmenin tek başına erişim kontrolü olmadığını ekledim.
- README.en.md içinde aynı Web Panel güvenlik notunu İngilizce olarak tamamladım.
- Türkçe ve İngilizce kullanım kılavuzlarında Web Panel güvenlik notuna aynı port/erişim kapsamı uyarısını ekledim.

## Why

Web Panel lighttpd + CGI ile yönetici seviyesinde işlemler yapabiliyor. Bu PR, panelin güven sınırını dokümanda daha görünür hale getirir ve kullanıcıların paneli güvenilir LAN dışına açmamasını açıkça söyler.

## Tests

- `git diff --check origin/main...HEAD`
- `rg -n "Web Panel|8088|güvenilir yerel ağ|trusted local networks|WAN|port forward|Port Forward|Port forwarding|misafir|Guest|IoT/VLAN|Changing the port number|Port numarasını değiştirmek" README.md README.en.md docs/kullanim_klavuzu.md docs/user_guide_en.md`

## Issue

Fixes #7
